### PR TITLE
Make role work in chroot

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-# tasks file for ansible-role-hp-serial
+# tasks file for ansible-role-serial
 
-  - include_tasks: redhat.yml
-    when: ansible_os_family == "RedHat" and ansible_system_vendor == "HP"
-
-  - include_tasks: redhat.yml
-    when: ansible_os_family == "RedHat" and ansible_system_vendor == "Dell Inc."
+- include_tasks: redhat.yml
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_connection != 'chroot'
+    - ansible_system_vendor == "HP" or ansible_system_vendor == "Dell Inc."


### PR DESCRIPTION
Ansible 2.8 made ansible_system_vendor unavailable in chroot's, thus
needs to be guarded by an extra test.  Also, clean up the logic a
little.